### PR TITLE
Corrects a CSS selector.

### DIFF
--- a/public/content-scripts/config/youtube.js
+++ b/public/content-scripts/config/youtube.js
@@ -3,7 +3,7 @@ class YouTubeConfig extends DualCaptionsConfig {
     super();
     this.site = "youtube";
     this.playerId = "movie_player";
-    this.captionWindowClass = "caption-window";
+    this.captionWindowClass = "ytp-caption-window-bottom";
     this.captionClass = "captions-text";
   }
 


### PR DESCRIPTION
I haven't tested this change (because my mac isn't letting me download Xcode developer tools).

This change may fix this problem:
The temporary caption window that says "Spanish (autogenerated). Click <> for settings" has the class "caption-window", so the additional captions are attached to that window, which disappears in a second, so the additional captions also disappear.