### PR TITLE
remove duplicated 'no-player' in locale fr

### DIFF
--- a/browser_action/public/locales/fr/translations.json
+++ b/browser_action/public/locales/fr/translations.json
@@ -13,7 +13,6 @@
   "beta-explanation": "Vous pouvez voir des bugs si vous utilisez cette extension sur les sites bêtas. Aidez-moi en rapportant les bugs sur GitHub.",
   "supports": "Compatible avec",
   "no-dc": "Deux Sous-titres n'est pas trouvé sur la page. Est-ce que vous êtes sur YouTube ou Netflix? Essayez de rafraîchir.",
-  "no-player": "Le player video n'est pas trouvé sur la page.",
   "generic-hint": "Sur la page, commencez les sous-titres.",
   "youtube-hint": "Sur YouTube, cliquez sur le bouton CC pour commencer les sous-titres.",
   "netflix-hint": "Sur Netflix, commencez les sous-titres.",


### PR DESCRIPTION
Two 'no-player' . Duplicated key. (line 24 and 16)

Got an error when I tried to submit a built copy to Firefox AMO. 

 --------------

BTW, could you have a quick look at https://github.com/mikesteele/dual-captions/issues/205. We would want this extension appear on AMO for Firefox users.